### PR TITLE
Fixed curl request for certain server configurations

### DIFF
--- a/src/Pakettikauppa/Client.php
+++ b/src/Pakettikauppa/Client.php
@@ -629,6 +629,8 @@ class Client
 
         $headers[] = 'Accept: application/json';
         $headers[] = 'Authorization: Basic ' .base64_encode("$user:$secret");
+        $headers[] = 'Content-Length: 0';
+        $headers[] = 'Expect:';
 
         $options = array(
             CURLOPT_POST            => 1,


### PR DESCRIPTION
As some server configurations (curl version maybe) requires correct content length this function would fail (usually due timeout) since content length would be -1.

`Expect:` header is a workaround for some server configurations that didnt support it `Expect: 100-Continue`. More info about expect header https://support.airship.com/hc/en-us/articles/213492003--Expect-100-Continue-Issues-and-Risks
