### PR TITLE
Fix deprecation notice in SimpleXMLElement

### DIFF
--- a/src/Pakettikauppa/SimpleXMLElement.php
+++ b/src/Pakettikauppa/SimpleXMLElement.php
@@ -8,15 +8,16 @@ class SimpleXMLElement extends \SimpleXMLElement
    * Escapes input text
    *
    * @param string
-   * @param string
+   * @param string|null
+   * @param string|null
    */
-  public function addChild($key, $value = null, $namespace = null)
+  public function addChild(string $qualifiedName, ?string $value = null, ?string $namespace = null): ?SimpleXMLElement
   {
     if ( $value != null )
     {
       $value = htmlspecialchars($value, ENT_XML1);
     }
 
-    return parent::addChild($key, $value, $namespace);
+    return parent::addChild($qualifiedName, $value, $namespace);
   }
 }


### PR DESCRIPTION
Fixes the following PHP deprecation notice:
```
PHP Deprecated:  Return type of Pakettikauppa\SimpleXMLElement::addChild($key, $value = null, $namespace = null) should either be compatible with SimpleXMLElement::addChild(string $qualifiedName, ?string $value = null, ?string $namespace = null): ?SimpleXMLElement, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in /.../vendor/pakettikauppa/api-library/src/Pakettikauppa/SimpleXMLElement.php on line 13
```