### PR TITLE
EP-322: Add params to list endpoints

### DIFF
--- a/src/Pakettikauppa/Client.php
+++ b/src/Pakettikauppa/Client.php
@@ -412,9 +412,9 @@ class Client
     /**
      * @return array
      */
-    public function listAdditionalServices()
+    public function listAdditionalServices($params = array())
     {
-        return json_decode($this->doPost('/additional-services/list', array()));
+        return json_decode($this->doPost('/additional-services/list', $params));
     }
 
     /**
@@ -429,9 +429,9 @@ class Client
     /**
      * @return array
      */
-    public function listShippingMethods()
+    public function listShippingMethods($params = array())
     {
-        return json_decode($this->doPost('/shipping-methods/list', array()));
+        return json_decode($this->doPost('/shipping-methods/list', $params));
     }
 
     /**


### PR DESCRIPTION
Added the ability to specify parameters for the `/additional-services/list` and `/shipping-methods/list` endpoints.
The change was made for backward compatibility and to allow any parameters to be specified.